### PR TITLE
PLAT-19 - add support for OTP 24 / elixir 1.12

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -84,7 +84,11 @@ defmodule Payeezy.HTTP do
   end
 
   defp generate_hmac(key, data) do
-    Base.encode64(Base.encode16(:crypto.hmac(:sha256, key, "#{data}"), case: :lower))
+    if Code.ensure_loaded?(:crypto) and function_exported?(:crypto, :mac, 4) do
+      Base.encode64(Base.encode16(:crypto.mac(:hmac, :sha256, key, "#{data}"), case: :lower))
+    else
+      Base.encode64(Base.encode16(:crypto.hmac(:sha256, key, "#{data}"), case: :lower))
+    end
   end
 
   defp generate_nonce do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Payeezy.Mixfile do
   use Mix.Project
 
-  @version "0.1.4"
+  @version "0.1.5"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Payeezy.Mixfile do
     [
       app: :payeezy,
       version: @version,
-      elixir: "~> 1.11.4",
+      elixir: "~> 1.11",
       elixirc_paths: elixrc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
The crypto functions in OTP have been revised with deprecations introduced in OTP 23 and the old versions have been completely removed in OTP 24. See: https://www.erlang.org/doc/general_info/deprecations.html#otp-23

As such this PR:
* Adds support for both the old and the new API which will allow this package to be used in systems running OTP 24 and higher
* Relaxed the elixir requirement so that systems using this package can upgrade to elixir 1.12 or higher

**QA**
I tested using `asdf` to have multiple local versions of elixir running. Add a `.tools-versions` file to the root of the project with these contents:
```
erlang 24.3.4.4
elixir 1.12.3-otp-24
```
Then run `mix test`. On master this will fail but on this branch it will pass.

To confirm it still works on elixir 1.11 / OTP 23 update your `.tools-versions` to:
```
erlang 23.3.4.5
elixir 1.11.4-otp-23
```
and run `mix test`