### PR TITLE
NERD-4368 Remove any trailing / in URL requests

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -36,7 +36,8 @@ defmodule Payeezy.HTTP do
   def process_url(path) do
     endpoint = Payeezy.get_env(:endpoint)
 
-    endpoint <> "/" <> path
+    (endpoint <> "/" <> path)
+    |> String.replace_suffix("/", "")
   end
 
   @doc false

--- a/lib/post_transaction.ex
+++ b/lib/post_transaction.ex
@@ -13,7 +13,7 @@ defmodule Payeezy.PostTransaction do
       {:error, ":econnrefused"} -> {:error, %{"description" => "econnrefused"}}
       {:error, ":closed"} -> {:error, %{"description" => "connection closed"}}
       {:error, other} ->
-        Logger.warn("Unhandled Payeezy client error: #{inspect(other)}")
+        Logger.warning("Unhandled Payeezy client error: #{inspect(other)}")
         {:error, %{"description" => "unknown client error"}}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Payeezy.Mixfile do
   use Mix.Project
 
-  @version "0.1.7"
+  @version "0.1.8"
 
   def project do
     [


### PR DESCRIPTION
Fiserv updated the runners for Payeezy to use Java 21. This means they no longer support requests with a trailing `/`.